### PR TITLE
Add a Kubernetes demo template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ We currently support a subset of Elasticsearch's query language, but are continu
 ## Next Steps
 You will want to try out Cloaked Search on some of your own data in a more real environment.
 
+Use the [Kubernetes template](kubernetes) in this repository to make a simple Kubernetes deployment.
+
 See the [configuration docs](https://ironcorelabs.com/docs/saas-shield/cloaked-search/configuration/) for info on how to configure and deploy Cloaked Search.
 
 If you are interested in the underlying technology, or the security of the underlying Elasticsearch index, see the [What Is Encrypted Search](https://ironcorelabs.com/docs/saas-shield/cloaked-search/what-is-encrypted-search/) page.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,51 @@
+# Contents
+
+This is a test deployment of cloaked-search, along with a demo deployment of Elasticsearch. The configurations are for illustrative
+purposes, not production.
+
+- [cs-deploy.yaml](cs-deploy.yaml): The [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) of the
+  Cloaked Search Proxy.
+- [cs-svc.yaml](cs-svc.yaml): A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) that clients can use to
+  connect to the Cloaked Search Proxy from within the same Kubernetes cluster. For access from external clients, consider setting
+  up an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
+- [es-deploy.yaml](es-deploy.yaml): An example Deployment of Elasticsearch. Unlike a production deployment, this has only one
+  replica.
+- [es-svc.yaml](es-svc.yaml): A Service that will be used by the Cloaked Search Proxy to send requests to Elasticsearch.
+- [kustomization.yaml](kustomization.yaml): A minimal [Kustomize](https://kubernetes-sigs.github.io/kustomize/) configuration to
+  control image tags and configuration used by the other files. If you don't want to use Kustomize, `kubectl kustomize . > csp.yaml`
+  from this directory will combine all the YAML configuration into a single `csp.yaml` file.
+- [ns.yaml](ns.yaml): Creates a dedicated [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+  for use by the CSP.
+- [pvc.yaml](pvc.yaml): A [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) used by
+  Elasticsearch to store its data. There is no PVC for the CSP, because it's stateless.
+
+# Deploy
+
+1. `kubectl create secret generic cloaked-search --from-file=../try-cloaked-search-conf.yaml=deploy.yml -n cloaked-search` to create
+    the Kubernetes secret containing the config file. (If the `cloaked-search` namespace doesn't exist yet, create it with
+    `kubectl create ns cloaked-search`.)
+1. Use `kubectl apply -k .` in this directory to start everything up.
+
+# Store documents
+
+If you're no longer running the Docker example from the parent directory, you can use the `populate_index.sh` script to store data
+to this Kubernetes deployment.
+
+1. `kubectl port-forward -n cloaked-search svc/cloaked-search 8675`
+1. In another terminal, `./populate_index.sh` from the root directory of this repository.
+
+# Post-deploy setup
+
+After starting this demo instance of elasticsearch, and after storing your first document, you need to tell it not to replicate its
+indices, since there's only one ES instance.
+
+1. `kubectl port-forward -n cloaked-search svc/elasticsearch 9200`
+1. `curl -X PUT -H "Content-type: application/json" -d '{ "index": { "number_of_replicas": 0 }}' http://localhost:9200/_settings`
+
+If you don't do this, elasticsearch status will change to yellow, which Kubernetes will interpret as "not ready" and take it of the
+service load balancer.
+
+# Querying
+
+Make sure you have a `kubectl port-forward` running, as described above, for port 8675. Then you can query the Kubernetes deployment
+using the instructions in the [repo root](../README.md).

--- a/kubernetes/cs-deploy.yaml
+++ b/kubernetes/cs-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloaked-search
+spec:
+  selector:
+    matchLabels:
+      app: cloaked-search
+  template:
+    metadata:
+      labels:
+        app: cloaked-search
+    spec:
+      containers:
+      - name: cloaked-search
+        image: cloaked-search-placeholder
+        env:
+          - name: RUST_LOG
+            value: info
+        resources:
+          limits:
+            memory: 500Mi
+            cpu: 2
+        ports:
+          - containerPort: 8675
+            name: http
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health?wait_for_status=green
+            port: http
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts:
+          - name: config
+            mountPath: /app/deploy.yml
+            subPath: deploy.yml
+      securityContext:
+        fsGroup: 1001
+      volumes:
+        - name: config
+          secret:
+            secretName: cloaked-search

--- a/kubernetes/cs-svc.yaml
+++ b/kubernetes/cs-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloaked-search
+spec:
+  selector:
+    app: cloaked-search
+  ports:
+    - port: 8675
+      name: http

--- a/kubernetes/es-deploy.yaml
+++ b/kubernetes/es-deploy.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elastic-search
+spec:
+  selector:
+    matchLabels:
+      app: elastic-search
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+  template:
+    metadata:
+      labels:
+        app: elastic-search
+    spec:
+      containers:
+      - name: elastic-search
+        image: elasticsearch-placeholder
+        env:
+          - name: discovery.type
+            value: single-node
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 2
+        ports:
+          - containerPort: 9200
+            name: http
+          - containerPort: 9300
+        livenessProbe:
+          httpGet:
+            path: /_cluster/health?wait_for_status=yellow
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health?wait_for_status=green
+            port: http
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+          - name: data
+            mountPath: /usr/share/elasticsearch/data
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: elasticsearch

--- a/kubernetes/es-svc.yaml
+++ b/kubernetes/es-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+spec:
+  selector:
+    app: elastic-search
+  ports:
+    - port: 9200
+      name: http

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -13,8 +13,8 @@ resources:
 
 images:
 - name: cloaked-search-placeholder
-  newName: gcr.io/ironcore-dev-1/cloaked-search
-  newTag: 0.1.61
+  newName: gcr.io/ironcore-images/cloaked-search
+  newTag: 0.1.48
 - name: elasticsearch-placeholder
   newName: elasticsearch
   newTag: 7.14.0

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cloaked-search
+
+resources:
+- cs-deploy.yaml
+- cs-svc.yaml
+- es-deploy.yaml
+- es-svc.yaml
+- ns.yaml
+- pvc.yaml
+
+images:
+- name: cloaked-search-placeholder
+  newName: gcr.io/ironcore-dev-1/cloaked-search
+  newTag: 0.1.61
+- name: elasticsearch-placeholder
+  newName: elasticsearch
+  newTag: 7.14.0

--- a/kubernetes/ns.yaml
+++ b/kubernetes/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloaked-search

--- a/kubernetes/pvc.yaml
+++ b/kubernetes/pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: elasticsearch
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
This template could be used by customers as a demo, or as a starting point for production.

When I copied this from its original location, I dropped this section from the docs. Should it be retained?

-----

Use a file like this, named `query.json`:
```json
{
  "size": 200,
  "query": {
    "query_string": {
        "query": "title:(bae) AND tenant_id:\"tenant-8\""
    }
  }
}
```

And try some different queries:
- `curl -H "Content-type: application/json" -d @query.json http://localhost:8675/big_wiki/_search`
    This should return the document you stored, because:
        - The document was stored via the CSP, which encrypted it.
        - The query is done via the CSP, so it can perform a query against the encrypted index.
        - The query specifies the correct `tenant_id`.
- Try the same query to port 9200 and it should fail. This query goes directly to Elasticsearch, and it's trying to query against
    an encrypted index using a plaintext query.
- Switch back to port 8675, and change the `tenant_id` to `tenant-7`. The query should fail.
- Replace the query term `title:bae` with `body:film`. The query should succeed, because the `body` field is not configured for
    encryption. (The `deploy.yml` configuration file only encrypts `title` and `summary` in the `big_wiki` index.)
- Remove the `tenant_id` from the query file, so the entire query term is `body:film`. Try this query against port 9200, and it
    should still succeed. This is directly asking Elasticsearch to search an unencrypted field.
