### PR TITLE
Don't index the _encrypted_source field

### DIFF
--- a/populate_index.sh
+++ b/populate_index.sh
@@ -10,7 +10,16 @@ else
    exit 2
 fi
 # Create the index in elastic search
-curl -s -X PUT localhost:8675/try_cloaked_search/
+curl --request PUT \
+  --url http://localhost:8675/try_cloaked_search \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"mappings": {
+		"properties": {
+			"_encrypted_source": { "enabled": false }
+		}
+	}
+}'
 
 # Configure the parallelism of the index
 NUM_THREADS=5


### PR DESCRIPTION
For https://github.com/IronCoreLabs/stretch-armstrong/issues/222

Disables the field in the populate script, 