### PR TITLE
Demonstrate mappings for efficient storage of protected indices

### DIFF
--- a/populate_index.sh
+++ b/populate_index.sh
@@ -15,7 +15,7 @@ curl -u admin:admin\
   --url http://localhost:8675/try_cloaked_search \
   --header 'Content-Type: application/json' \
   --data '{
-	"mappings": {
+  "mappings": {
     "dynamic_templates": [
           {
             "protected_fields": {
@@ -27,11 +27,11 @@ curl -u admin:admin\
             }
           }
         ],
-		"properties": {
-			"_icl_encrypted_source": { "enabled": false },
+    "properties": {
+      "_icl_encrypted_source": { "enabled": false },
       "_icl_search_key_id" : { "type": "keyword" }
-		}
-	}
+    }
+  }
 }'
 
 # Configure the parallelism of the index

--- a/populate_index.sh
+++ b/populate_index.sh
@@ -17,21 +17,22 @@ curl -u admin:admin\
   --data '{
   "mappings": {
     "dynamic_templates": [
-          {
-            "protected_fields": {
-              "match_mapping_type": "string",
-              "match": "_icl_p_*",
-              "mapping": {
-                "type": "text"
-              }
-            }
+      {
+        "protected_fields": {
+          "match_mapping_type": "string",
+          "match": "_icl_p_*",
+          "mapping": {
+            "type": "text"
           }
-        ],
+        }
+      }
+    ],
     "properties": {
       "_icl_encrypted_source": { "enabled": false },
-      "_icl_search_key_id" : { "type": "keyword" }
+      "_icl_search_key_id": { "type": "keyword" }
     }
   }
+
 }'
 
 # Configure the parallelism of the index

--- a/populate_index.sh
+++ b/populate_index.sh
@@ -16,8 +16,20 @@ curl -u admin:admin\
   --header 'Content-Type: application/json' \
   --data '{
 	"mappings": {
+    "dynamic_templates": [
+          {
+            "protected_fields": {
+              "match_mapping_type": "string",
+              "match": "_icl_p_*",
+              "mapping": {
+                "type": "text"
+              }
+            }
+          }
+        ],
 		"properties": {
-			"_icl_encrypted_source": { "enabled": false }
+			"_icl_encrypted_source": { "enabled": false },
+      "_icl_search_key_id" : { "type": "keyword" }
 		}
 	}
 }'


### PR DESCRIPTION
Adds the following config for the `try_cloaked_search` protected index.

```json
"mappings": {
    "dynamic_templates": [
          {
            "protected_fields": {
              "match_mapping_type": "string",
              "match": "_icl_p_*",
              "mapping": {
                "type": "text"
              }
            }
          }
        ],
  "properties": {
    "_icl_encrypted_source": { "enabled": false },
    "_icl_search_key_id" : { "type": "keyword" }
  }
}	
```