### PR TITLE
Bump cloaked-search to the newest version

### DIFF
--- a/elasticsearch/docker-compose.yml
+++ b/elasticsearch/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       discovery.type: "single-node"
       xpack.security.enabled: "false"
   cloaked-search:
-    image: "gcr.io/ironcore-images/cloaked-search:2.4.3"
+    image: "gcr.io/ironcore-images/cloaked-search:2.10.2"
     ports:
       - 8675:8675
     volumes:

--- a/open-search/docker-compose.yml
+++ b/open-search/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       discovery.type: "single-node"
       plugins.security.disabled: "true"
   cloaked-search:
-    image: "gcr.io/ironcore-images/cloaked-search:2.4.3"
+    image: "gcr.io/ironcore-images/cloaked-search:2.10.2"
     ports:
       - 8675:8675
     volumes:


### PR DESCRIPTION
Hello 👋 

I've just tried to start Cloaked Search for Elasticsearch and got the error that the version `2.4.3` cannot be found. 
```
 ✘ Image gcr.io/ironcore-images/cloaked-search:2.4.3 Error manifest for gcr.io/ironcore-images/cloaked-search:2.4.3 not found: manifest unknown: Failed to fetch "2.4.3"      6.5s
Error response from daemon: manifest for gcr.io/ironcore-images/cloaked-search:2.4.3 not found: manifest unknown: Failed to fetch "2.4.3"
```

So I decided to contribute to this repo 😊 
Could we bump the version to the newest one, please? 